### PR TITLE
Allow non-integer id's in JSON RPC requests

### DIFF
--- a/src/sockthing/StratumConnection.java
+++ b/src/sockthing/StratumConnection.java
@@ -217,13 +217,13 @@ public class StratumConnection
     private void processInMessage(JSONObject msg)
         throws Exception
     {
-        long id = msg.getLong("id");
-        if (id == get_client_id)
+        long idx = msg.optLong("id",-1);
+        if (idx != -1 && idx == get_client_id)
         {
             client_version = msg.getString("result");
             return;
         }
-       
+        Object id = msg.opt("id");
         if (!msg.has("method"))
         {
             System.out.println("Unknown message: " + msg.toString());


### PR DESCRIPTION
I've noticed some clients sending a non-numeric "id" in the JSON RPC request when doing a subscribe request. In particular one was sending the string "s". The JSON RPC spec allows numbers and strings.

This patch uses "optLong" instead of "getLong" to avoid failing with an exception, and where the "id" returned back to the client it uses "opt" to deal with whatever format the original request used.
