### PR TITLE
Flush output stream and disable TCP Nagle algorithm

### DIFF
--- a/src/sockthing/StratumConnection.java
+++ b/src/sockthing/StratumConnection.java
@@ -152,6 +152,7 @@ public class StratumConnection
 
                         String msg_str = msg.toString();
                         out.println(msg_str);
+                        out.flush();
 
                         System.out.println("Out: " + msg.toString());
                         updateLastNetworkAction();

--- a/src/sockthing/StratumServer.java
+++ b/src/sockthing/StratumServer.java
@@ -204,6 +204,7 @@ public class StratumServer
                     try
                     {
                         Socket sock = ss.accept();
+                        sock.setTcpNoDelay(true);
 
                         String id = UUID.randomUUID().toString();
 


### PR DESCRIPTION
On cgminer 3.x using some USB ASIC devices there are issues with
cgminer disconnecting during a read_line call. The read_line in
cgminer times out while waiting for a complete line of data from
the stratum server. Flushing the output and disabling the Nagle
algorithm fixes the issue.
