### PR TITLE
Prevent share submission with JSON id's matching client request id's fro...

### DIFF
--- a/src/sockthing/StratumConnection.java
+++ b/src/sockthing/StratumConnection.java
@@ -219,7 +219,7 @@ public class StratumConnection
         throws Exception
     {
         long idx = msg.optLong("id",-1);
-        if (idx != -1 && idx == get_client_id)
+        if (idx != -1 && idx == get_client_id && msg.has("result"))
         {
             client_version = msg.getString("result");
             return;


### PR DESCRIPTION
...m clashing

When client submits a share to the server with an "id" in the JSON
msg that matches a "client get version" request we've asked for
previously, the share submission gets mistaken as a response for
that request. This happens when the JSON id is 10,000 due to the
default request number set for the client requests.

The fix is to make sure the JSON msg is a reply by checking that
it contains a "result" field.
